### PR TITLE
Updated Readme to fix the path example by removing wp-json from it.

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -17,7 +17,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```js
 import apiFetch from '@wordpress/api-fetch';
 
-apiFetch( { path: '/wp-json/wp/v2/posts' } ).then( posts => {
+apiFetch( { path: '/wp/v2/posts' } ).then( posts => {
 	console.log( posts );
 } );
 ```


### PR DESCRIPTION
While testing the apiFetch component we realised that the path didn't need to include wp-json because that has already been added.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
